### PR TITLE
Webserver: Fix setLogLevel is not persistent across reboot

### DIFF
--- a/src/Web/WebServer.cpp
+++ b/src/Web/WebServer.cpp
@@ -746,7 +746,7 @@ void WebPortal::handleLogLevel(AsyncWebServerRequest *request)
         LogLevel level = logger.levelFromString(levelStr);
 
         // Set new level
-        logger.setLogLevel(level);
+        configManager.setLogLevel(level);
     }
 
     // Redirect back to logs page


### PR DESCRIPTION
In webserver is badly called "logger" class instead of configManager class, result is log level is not saved.