### PR TITLE
Fixed Unavailable device in HA when it is first one

### DIFF
--- a/src/Protocol/MQTTManager.cpp
+++ b/src/Protocol/MQTTManager.cpp
@@ -87,10 +87,13 @@ bool MQTTManager::connect()
     {
         logger.info("Connected to MQTT broker");
 
-        mqttClient.publish("explora/status", "online", true);
-
         // Publish discovery information after successful connection
         publishDiscovery();
+
+        // TODO: Some better idea than magic number delay?
+        // Give HA time to subscribe this topic
+        delay(500);
+        mqttClient.publish("explora/status", "online", true);
     }
     else
     {


### PR DESCRIPTION
If there is nothing in HA yet from explora, then Home Assistant does not see "status/online" message, because does not listen on enplora/# topic yet.

So swap discovery and online messages and give ungly 500ms "time" to HA will be already subscribed to explora/status topic

It causes unavailable sensors until gateway is reset. After that it should work until last MQTT expLora device is not deleted, so HA will stay on explora topic.

It is not such big deal, but it may confuse new users with "unavailable" message and this could fix lot of headache on First level support

![image](https://github.com/user-attachments/assets/e231a1dd-2617-4968-9595-9f8558911e2a)
