### PR TITLE
Fix SDK version to prevent unexpected results on different environments

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@ build_flags =
         -I variants/${PIOENV}
 
 [env]
-platform = espressif32
+platform = espressif32 @ 6.11.0
 framework = arduino
 
 monitor_speed = 115200


### PR DESCRIPTION
Stick on well know to working SDK version, if build env contains some different version, it is used as-is and it may cause build errors