### PR TITLE
Removed unprintable char causes build error

### DIFF
--- a/src/Data/SensorManager.cpp
+++ b/src/Data/SensorManager.cpp
@@ -359,7 +359,7 @@ bool SensorManager::updateSensorData(int index, float temperature, float humidit
         sensors[index].dailyRainTotal += rainAmount;
 
         // Log the updated daily total if it has changed
-        if (rainAmount > 0)
+        if (rainAmount > 0)
         {
            saveSensors(false); // Save immediately after updating daily total
         }


### PR DESCRIPTION
There is some unprintable char, which cause build error, this fixes it

```
src/Data/SensorManager.cpp:362:25: error: stray '\302' in program
         if (rainAmount > 0)
                         ^
src/Data/SensorManager.cpp:362:26: error: stray '\240' in program
         if (rainAmount > 0)
```